### PR TITLE
Additions to voids.sc script for 1.18.2+ usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You need the [Carpet mod](https://www.curseforge.com/minecraft/mc-mods/carpet) t
 
 ## Voids
 
-**This is now dead in 1.18.2, dimensions created earlier will still work, but the carpet mod removed the interface that was used for creating new dimensions, so that is no longer possible.**
+**This script works differently in 1.18.2. You must reopen the world for newly created dimensions to be accessible.**
 
 [voids.sc](voids.sc) contains the creative tool for managing multiple dimensions inside one creative world.
 The commands it provides are:

--- a/voids.sc
+++ b/voids.sc
@@ -39,6 +39,15 @@ add(name,biome) -> (
     print_dim(name, dimname);
 );
 
+disable(name) -> (
+    dims = get(global_settings, 'dimensions');
+    if (!has(dims, name), _error('Dimension does not exist'));
+    delete(dims, name);
+    put(global_settings, 'dimensions', dims);
+    save_settings();
+    print(name + ' successfully disabled')
+);
+
 print_dim(name, dimname) -> (
     print(player(), format(str('d %s', name), str('^mi Teleport to %s', name), str('!/execute in %s run tp %s 0 65 0', dimname, player())))
 );
@@ -65,11 +74,18 @@ __config() -> {
     'commands' -> {
         'add <name>' -> [ 'add', 'minecraft:plains' ],
 	'add <name> <biome>' -> 'add',
+	    'disable <disable_dim>' -> 'disable',
         'list' -> 'list',
         'tp <string>' -> 'tp', 
     },
     'arguments' -> {
         'name' -> { 'type' -> 'string' },
         'biome' -> { 'type' -> 'biome', 'suggest' -> biome() },
+        'disable_dim' -> {
+            'type' -> 'term', 
+            'suggester' -> _(args) -> (
+                keys(get(global_settings, 'dimensions'));
+            ),
+        }
     },
 };

--- a/voids.sc
+++ b/voids.sc
@@ -72,8 +72,8 @@ __config() -> {
     'scope' -> 'global',
     'stay_loaded' -> true,
     'commands' -> {
-        'add <name>' -> [ 'add', 'minecraft:plains' ],
-	'add <name> <biome>' -> 'add',
+        'add <name>' -> [ 'add', 'minecraft:the_void' ],
+	    'add <name> <biome>' -> 'add',
 	    'disable <disable_dim>' -> 'disable',
         'list' -> 'list',
         'tp <string>' -> 'tp', 

--- a/voids.sc
+++ b/voids.sc
@@ -33,8 +33,6 @@ add(name,biome) -> (
 		}
 	    }
     }}}}});
-    enable_hidden_dimensions();
-    in_dimension(dimname, set(0, 63, 0, block('stone')));   
     put(dims, name, dimname);
     put(global_settings, 'dimensions', dims);
     save_settings();

--- a/voids.sc
+++ b/voids.sc
@@ -22,17 +22,16 @@ add(name,biome) -> (
     create_datapack(dimname, {
         'data' -> { 'minecraft' -> { 'dimension' -> { dimname + '.json' -> { 
             'type' -> 'minecraft:overworld',
-	    'generator' -> {
-		'type' -> 'minecraft:flat',
-		'settings' -> {
-		    'layers' -> [],
-		    'biome' -> biome,
-		    'structures' -> {
-			'structures' -> {}
-		    }
-		}
-	    }
-    }}}}});
+	        'generator' -> {
+		        'type' -> 'minecraft:flat',
+		        'settings' -> {
+		            'layers' -> [],
+		            'biome' -> biome,
+		            'structure_overrides' -> 'minecraft:end_cities'
+		        }
+	        }
+        }
+    }}}});
     put(dims, name, dimname);
     put(global_settings, 'dimensions', dims);
     save_settings();

--- a/voids.sc
+++ b/voids.sc
@@ -75,11 +75,19 @@ __config() -> {
 	    'add <name> <biome>' -> 'add',
 	    'disable <disable_dim>' -> 'disable',
         'list' -> 'list',
-        'tp <string>' -> 'tp', 
+        'tp <tp_dim>' -> 'tp', 
     },
     'arguments' -> {
         'name' -> { 'type' -> 'string' },
         'biome' -> { 'type' -> 'biome', 'suggest' -> biome() },
+        'tp_dim' -> {
+            'type' -> 'term', 
+            'suggester' -> _(args) -> (
+                dims_suggest = get(global_settings, 'dimensions');
+                for({'overworld', 'the_nether', 'the_end'}, put(dims_suggest, _, _));
+                keys(dims);
+            ),
+        },
         'disable_dim' -> {
             'type' -> 'term', 
             'suggester' -> _(args) -> (

--- a/voids.sc
+++ b/voids.sc
@@ -85,7 +85,7 @@ __config() -> {
             'suggester' -> _(args) -> (
                 dims_suggest = get(global_settings, 'dimensions');
                 for({'overworld', 'the_nether', 'the_end'}, put(dims_suggest, _, _));
-                keys(dims);
+                keys(dims_suggest);
             ),
         },
         'disable_dim' -> {


### PR DESCRIPTION
This PR does a couple things

- Removes carpet functions that break usage in 1.18.2, instead suggesting to manually reopen the world
- Adds a disable command to softly remove dimensions. Full removal will require manual deletion of the datapack and dimension folder in order to prevent accidental data loss.
- Changes the default biome to void and overrides structure generation
  - A problem when using mods that dynamically generate a void world, ie ProtoSky, is that new void worlds can generate villages. This overrides structure generations to only attempt to generate end cities, which can never occur in the overworld, allowing for a fully void world.
- Adds suggestions for the `tp` command